### PR TITLE
New Widgets

### DIFF
--- a/src/components/widgets/FutureCostWidget.tsx
+++ b/src/components/widgets/FutureCostWidget.tsx
@@ -8,33 +8,45 @@ import {
 } from 'components/widgets/shared/BasicAxes';
 import {LinearAreaSeries} from 'components/widgets/shared/BasicAreaSeries';
 import * as util from './shared/util';
-import {AfterTimeTickMark} from "./shared/TimeTickMark";
+import {IPoint} from 'types/IPoint';
+import {AfterTimeTickMark} from 'components/widgets/shared/TimeTickMark';
+import {LinearLineSeries} from 'components/widgets/shared/BasicLineSeries';
 
 
-//Date should be sorted now.
-export interface IElevationWidgetProps extends IDefaultWidgetProps {}
+export interface IFutureCostWidget extends IDefaultWidgetProps {
+  elevationData: IPoint[];
+}
+//TODO(klare): add in and statements into the status.
+//TODO(klare): integrate actual live data and see how it looks.
 
-export const ElevationWidget: React.FC<IElevationWidgetProps> = props => (
+export const FutureCostWidget: React.FC<IFutureCostWidget> = props => (
   <XYPlotTemplate
     heightPx={props.heightPx}
     widthPx={props.widthPx}
     status={props.data.length > 2 && props.data.length > 2 ? 'ready' : 'loading'}
-    title="Elevation over Predicted Time"
+    title="Cost Of Resting over Time/Elevation"
     useHorizontalGridLines={true}>
+
     {LinearAreaSeries({
-      data: props.data,
+      data: props.elevationData,
       lineColor: 'orange',
       fillColor: '#FFCF9E',
       lineWidthPx: util.StrokeWidthPx
     })}
 
+    {LinearLineSeries ({
+      data: props.data,
+      lineColor: 'purple',
+      lineWidthPx: util.StrokeWidthPx
+    })}
+
     {BasicHorizontalAxis({
-      axisLabel: "Time (h:m:s ago)",
+      axisLabel: "Time (Minutes)",
       fnTickFormat: t => AfterTimeTickMark({unixTime: t})
     })}
 
     {BasicVerticalAxis({
-      axisLabel: "Elevation Level"
+      axisLabel: "Cost of resting"
     })}
   </XYPlotTemplate>
 );

--- a/src/components/widgets/FutureHumidityWidget.tsx
+++ b/src/components/widgets/FutureHumidityWidget.tsx
@@ -8,33 +8,45 @@ import {
 } from 'components/widgets/shared/BasicAxes';
 import {LinearAreaSeries} from 'components/widgets/shared/BasicAreaSeries';
 import * as util from './shared/util';
-import {AfterTimeTickMark} from "./shared/TimeTickMark";
+import {IPoint} from 'types/IPoint';
+import {AfterTimeTickMark} from 'components/widgets/shared/TimeTickMark';
+import {LinearLineSeries} from 'components/widgets/shared/BasicLineSeries';
 
 
-//Date should be sorted now.
-export interface IElevationWidgetProps extends IDefaultWidgetProps {}
+export interface IFutureHumidityWidget extends IDefaultWidgetProps {
+  elevationData: IPoint[];
+}
+//TODO(klare): add in and statements into the status.
+//TODO(klare): integrate actual live data and see how it looks.
 
-export const ElevationWidget: React.FC<IElevationWidgetProps> = props => (
+export const FutureHumidityWidget: React.FC<IFutureHumidityWidget> = props => (
   <XYPlotTemplate
     heightPx={props.heightPx}
     widthPx={props.widthPx}
     status={props.data.length > 2 && props.data.length > 2 ? 'ready' : 'loading'}
-    title="Elevation over Predicted Time"
+    title="Temperature over Elevation"
     useHorizontalGridLines={true}>
+
     {LinearAreaSeries({
-      data: props.data,
+      data: props.elevationData,
       lineColor: 'orange',
       fillColor: '#FFCF9E',
       lineWidthPx: util.StrokeWidthPx
     })}
 
+    {LinearLineSeries ({
+      data: props.data,
+      lineColor: 'blue',
+      lineWidthPx: util.StrokeWidthPx
+    })}
+
     {BasicHorizontalAxis({
-      axisLabel: "Time (h:m:s ago)",
+      axisLabel: "Time (Minutes)",
       fnTickFormat: t => AfterTimeTickMark({unixTime: t})
     })}
 
     {BasicVerticalAxis({
-      axisLabel: "Elevation Level"
+      axisLabel: "Humidity %"
     })}
   </XYPlotTemplate>
 );

--- a/src/components/widgets/FutureTempWidget.tsx
+++ b/src/components/widgets/FutureTempWidget.tsx
@@ -8,33 +8,45 @@ import {
 } from 'components/widgets/shared/BasicAxes';
 import {LinearAreaSeries} from 'components/widgets/shared/BasicAreaSeries';
 import * as util from './shared/util';
-import {AfterTimeTickMark} from "./shared/TimeTickMark";
+import {IPoint} from 'types/IPoint';
+import {AfterTimeTickMark} from 'components/widgets/shared/TimeTickMark';
+import {LinearLineSeries} from 'components/widgets/shared/BasicLineSeries';
 
 
-//Date should be sorted now.
-export interface IElevationWidgetProps extends IDefaultWidgetProps {}
+export interface IFutureTempWidget extends IDefaultWidgetProps {
+  elevationData: IPoint[];
+}
+//TODO(klare): add in and statements into the status.
+//TODO(klare): integrate actual live data and see how it looks.
 
-export const ElevationWidget: React.FC<IElevationWidgetProps> = props => (
+export const FutureTempWidget: React.FC<IFutureTempWidget> = props => (
   <XYPlotTemplate
     heightPx={props.heightPx}
     widthPx={props.widthPx}
     status={props.data.length > 2 && props.data.length > 2 ? 'ready' : 'loading'}
-    title="Elevation over Predicted Time"
+    title="Temperature over Elevation"
     useHorizontalGridLines={true}>
+
     {LinearAreaSeries({
-      data: props.data,
+      data: props.elevationData,
       lineColor: 'orange',
       fillColor: '#FFCF9E',
       lineWidthPx: util.StrokeWidthPx
     })}
 
+    {LinearLineSeries ({
+      data: props.data,
+      lineColor: 'red',
+      lineWidthPx: util.StrokeWidthPx
+    })}
+
     {BasicHorizontalAxis({
-      axisLabel: "Time (h:m:s ago)",
+      axisLabel: "Time (Minutes)",
       fnTickFormat: t => AfterTimeTickMark({unixTime: t})
     })}
 
     {BasicVerticalAxis({
-      axisLabel: "Elevation Level"
+      axisLabel: "Temperature"
     })}
   </XYPlotTemplate>
 );

--- a/src/pages/TeamPage/CourseAwarenessSection/CourseAwarenessSection.tsx
+++ b/src/pages/TeamPage/CourseAwarenessSection/CourseAwarenessSection.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 import {Section} from 'components/layout/Section/Section';
 import {Heading} from 'components/Heading/Heading';
 import {RedWord} from 'components/RedWord/RedWord';
-import {ElevationWidget} from 'components/widgets/ElevationWidget';
-import {CostOfRestWidget} from 'components/widgets/CostOfRestWidget';
+
 import {FlexCell} from 'components/layout/FlexCell';
 import {SelectField} from 'components/form/fields/SelectField';
 import {IPoint} from 'types/IPoint';
@@ -12,9 +11,16 @@ import {FlexColumn} from 'components/layout/FlexColumn';
 import {InputRow} from 'components/form/InputRow/InputRow';
 import {StackedInputCell} from 'components/form/StackedInputCell/StackedInputCell';
 
+//widgets
+import {ElevationWidget} from 'components/widgets/ElevationWidget';
+//import {CostOfRestWidget} from 'components/widgets/CostOfRestWidget';
+import {WindForecastWidget} from 'components/widgets/WindForecastWidget';
+//import {FutureCostWidget} from 'components/widgets/FutureCostWidget';
+//import {FutureTempWidget} from 'components/widgets/FutureTempWidget';
+//import {FutureHumidityWidget} from 'components/widgets/FutureHumidityWidget';
+
+
 import globalStyles from 'globalStyles.module.css';
-
-
 
 const AWARENESS_SELECT_VALUES = [
   {id: "120", displayValue: "2 hours"},
@@ -52,29 +58,64 @@ export const CourseAwarenessSection: React.FC<ICourseAwarenessSectionProps> = pr
         </StackedInputCell>
       </InputRow>
 
+
       <FlexCell className={globalStyles.marginBottom}>
-        <CostOfRestWidget
+        <ElevationWidget
           numPointsBeforeLoad={props.numPointsBeforeLoad}
+          data={props.elevation}
+          heightPx={props.graphHeightPx}
+          widthPx={props.graphWidthPx} />
+      </FlexCell>
+
+
+      <FlexCell className={globalStyles.marginBottom}>
+        <WindForecastWidget
+          numPointsBeforeLoad={props.numPointsBeforeLoad}
+          elevationData={props.elevation}
+          forecastedWind={props.tailwind2hrs}
           data={props.tailwindnow}
           heightPx={props.graphHeightPx}
           widthPx={props.graphWidthPx} />
       </FlexCell>
 
-      <FlexCell className={globalStyles.marginBottom}>
-        <ElevationWidget
-          numPointsBeforeLoad={props.numPointsBeforeLoad}
-          data={props.elevation}
-          heightPx={props.graphHeightPx}
-          widthPx={props.graphWidthPx} />
-      </FlexCell>
 
-      <FlexCell className={globalStyles.marginBottom}>
-        <ElevationWidget
-          numPointsBeforeLoad={props.numPointsBeforeLoad}
-          data={props.elevation}
-          heightPx={props.graphHeightPx}
-          widthPx={props.graphWidthPx} />
-      </FlexCell>
     </FlexColumn>
   </Section>
 );
+
+//TODO
+/**
+CURRENT FEATURES:
+  Elevation data isn't scaling right.
+*/
+
+/* We will want these later
+//This is the good stuff that we REALLY want.
+<FlexCell className={globalStyles.marginBottom}>
+  <FutureCostWidget
+    numPointsBeforeLoad={props.numPointsBeforeLoad}
+    elevationData={props.elevation}
+    data={props.time_cost_of_rest}
+    heightPx={props.graphHeightPx}
+    widthPx={props.graphWidthPx} />
+</FlexCell>
+
+<FlexCell className={globalStyles.marginBottom}>
+  <FutureTempWidget
+    numPointsBeforeLoad={props.numPointsBeforeLoad}
+    elevationData={props.elevation}
+    data={props.predicted_temperature}
+    heightPx={props.graphHeightPx}
+    widthPx={props.graphWidthPx} />
+</FlexCell>
+
+//Unsure if we will be able to get this.
+<FlexCell className={globalStyles.marginBottom}>
+  <FutureHumidityWidget
+    numPointsBeforeLoad={props.numPointsBeforeLoad}
+    elevationData={props.elevation}
+    data={props.predicted_humidity}
+    heightPx={props.graphHeightPx}
+    widthPx={props.graphWidthPx} />
+</FlexCell>
+*/


### PR DESCRIPTION
TL;DR New widgets.  If WindForecastWidget fails, they all do. Added in sample code once/if data is piped in.

In a very poorly worded branch, I've created several new widgets (optimization, temp, humidity) which will perform the tasks that are wanted from @bartondoug. However, these are heavily based off of an earlier pr (the WindForecastWidget) and if that isn't working as intended, these likely wont. 

Rayhan will most likely work on scaling elevation to match these graphs tomorrow morning.  If that doesn't work, we will remove the elevation component from each of these graphs and just have simple line graphs. 